### PR TITLE
Remove redundant call of $db->tableName() (#6150)

### DIFF
--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -589,9 +589,13 @@ class SMWExportController {
 				$query .= 'page_namespace = ' . $dbr->addQuotes( $ns );
 			}
 		}
-		$res = $dbr->select( $dbr->tableName( 'page' ),
-							'page_id,page_title,page_namespace', $query,
-							'SMW::RDF::PrintPageList', [ 'ORDER BY' => 'page_id ASC', 'OFFSET' => $offset, 'LIMIT' => $limit ] );
+		$res = $dbr->select(
+			'page',
+			'page_id,page_title,page_namespace',
+			$query,
+			'SMW::RDF::PrintPageList',
+			[ 'ORDER BY' => 'page_id ASC', 'OFFSET' => $offset, 'LIMIT' => $limit ]
+		);
 		$foundpages = false;
 
 		foreach ( $res as $row ) {

--- a/includes/specials/SpecialConcepts.php
+++ b/includes/specials/SpecialConcepts.php
@@ -89,15 +89,15 @@ class SpecialConcepts extends \SpecialPage {
 
 		$res = $connection->select(
 			[
-				$connection->tableName( SQLStore::ID_TABLE ),
-				$connection->tableName( SQLStore::CONCEPT_TABLE )
+				SQLStore::ID_TABLE,
+				SQLStore::CONCEPT_TABLE
 			],
 			$fields,
 			$conditions,
 			__METHOD__,
 			$options,
 			[
-				$connection->tableName( SQLStore::ID_TABLE ) => [ 'INNER JOIN', [ 'smw_id=s_id' ] ]
+				SQLStore::ID_TABLE => [ 'INNER JOIN', [ 'smw_id=s_id' ] ]
 			]
 		);
 

--- a/src/MediaWiki/Api/Browse/ListLookup.php
+++ b/src/MediaWiki/Api/Browse/ListLookup.php
@@ -212,7 +212,7 @@ class ListLookup extends Lookup {
 		$connection = $this->store->getConnection( 'mw.db' );
 
 		$res = $connection->select(
-			$connection->tableName( SQLStore::ID_TABLE ),
+			SQLStore::ID_TABLE,
 			$fields,
 			$conditions,
 			__METHOD__,

--- a/src/SQLStore/EntityStore/AuxiliaryFields.php
+++ b/src/SQLStore/EntityStore/AuxiliaryFields.php
@@ -126,10 +126,9 @@ class AuxiliaryFields {
 	private function fetchCountMap( array $hashes ) {
 		return $this->connection->select(
 			[
-				// tableName conversion required by SQlite otherwise the
-				// integration tests fail
-				't' => $this->connection->tableName( SQLStore::ID_TABLE ),
-				'p' => $this->connection->tableName( SQLStore::ID_AUXILIARY_TABLE ) ],
+				't' => SQLStore::ID_TABLE,
+				'p' => SQLStore::ID_AUXILIARY_TABLE
+			],
 			[
 				't.smw_id',
 				't.smw_hash',

--- a/src/SQLStore/EntityStore/EntityIdFinder.php
+++ b/src/SQLStore/EntityStore/EntityIdFinder.php
@@ -280,8 +280,7 @@ class EntityIdFinder {
 		}
 
 		$rows = $this->connection->select(
-			// This should be necessary but somehow `SQLite` fails here
-			$this->connection->tableName( SQLStore::ID_TABLE ),
+			SQLStore::ID_TABLE,
 			[
 				'smw_id'
 			],

--- a/src/SQLStore/EntityStore/SubobjectListFinder.php
+++ b/src/SQLStore/EntityStore/SubobjectListFinder.php
@@ -129,7 +129,7 @@ class SubobjectListFinder {
 		}
 
 		$res = $connection->select(
-			$connection->tablename( SQLStore::ID_TABLE ),
+			SQLStore::ID_TABLE,
 			[
 				'smw_id',
 				'smw_subobject',

--- a/src/SQLStore/Lookup/ByGroupPropertyValuesLookup.php
+++ b/src/SQLStore/Lookup/ByGroupPropertyValuesLookup.php
@@ -192,9 +192,9 @@ class ByGroupPropertyValuesLookup {
 		if ( $isIdField ) {
 			$res = $connection->select(
 				[
-					'o' => $connection->tableName( SQLStore::ID_TABLE ),
-					'p' => $connection->tableName( $propTable->getName() ),
-					'i' => $connection->tableName( SQLStore::ID_TABLE )
+					'o' => SQLStore::ID_TABLE,
+					'p' => $propTable->getName(),
+					'i' => SQLStore::ID_TABLE
 				],
 				$fields,
 				[
@@ -215,8 +215,8 @@ class ByGroupPropertyValuesLookup {
 		} else {
 			$res = $connection->select(
 				[
-					'o' => $connection->tableName( SQLStore::ID_TABLE ),
-					'p' => $connection->tableName( $propTable->getName() )
+					'o' => SQLStore::ID_TABLE,
+					'p' => $propTable->getName()
 				],
 				$fields,
 				[

--- a/src/SQLStore/Lookup/ChangePropagationEntityLookup.php
+++ b/src/SQLStore/Lookup/ChangePropagationEntityLookup.php
@@ -160,7 +160,7 @@ class ChangePropagationEntityLookup {
 
 			// Select any references that are hidden or remained active
 			$rows = $connection->select(
-				$connection->tableName( $tableName ),
+				$tableName,
 				[
 					's_id'
 				],

--- a/src/SQLStore/Lookup/DisplayTitleLookup.php
+++ b/src/SQLStore/Lookup/DisplayTitleLookup.php
@@ -122,7 +122,7 @@ class DisplayTitleLookup {
 		$propTable = $propTables[$propTableId];
 
 		$rows = $connection->select(
-			$connection->tablename( $propTable->getName() ),
+			$propTable->getName(),
 			[
 				's_id',
 				'o_hash',

--- a/src/SQLStore/Lookup/PropertyUsageListLookup.php
+++ b/src/SQLStore/Lookup/PropertyUsageListLookup.php
@@ -115,12 +115,12 @@ class PropertyUsageListLookup implements ListLookup {
 		$db = $this->store->getConnection( 'mw.db' );
 
 		$res = $db->select(
-			[ $db->tableName( SQLStore::ID_TABLE ), $db->tableName( SQLStore::PROPERTY_STATISTICS_TABLE ) ],
+			[ SQLStore::ID_TABLE, SQLStore::PROPERTY_STATISTICS_TABLE ],
 			[ 'smw_id', 'smw_title', 'usage_count' ],
 			$conditions,
 			__METHOD__,
 			$options,
-			[ $db->tableName( SQLStore::ID_TABLE ) => [ 'INNER JOIN', [ 'smw_id=p_id' ] ] ]
+			[ SQLStore::ID_TABLE => [ 'INNER JOIN', [ 'smw_id=p_id' ] ] ]
 		);
 
 		return $res;

--- a/src/SQLStore/Lookup/RedirectTargetLookup.php
+++ b/src/SQLStore/Lookup/RedirectTargetLookup.php
@@ -64,7 +64,7 @@ class RedirectTargetLookup {
 		$connection = $this->store->getConnection( 'mw.db' );
 
 		$rows = $connection->select(
-			$connection->tableName( RedirectStore::TABLE_NAME ),
+			RedirectStore::TABLE_NAME,
 			[
 				'o_id',
 				's_title',

--- a/src/SQLStore/Lookup/UsageStatisticsListLookup.php
+++ b/src/SQLStore/Lookup/UsageStatisticsListLookup.php
@@ -206,12 +206,12 @@ class UsageStatisticsListLookup implements ListLookup {
 
 		// Select object ID's against known property ID's that match the conditions
 		$res = $db->select(
-			[ $db->tableName( SQLStore::ID_TABLE ), $db->tableName( SQLStore::PROPERTY_STATISTICS_TABLE ) ],
+			[ SQLStore::ID_TABLE, SQLStore::PROPERTY_STATISTICS_TABLE ],
 			'smw_id',
 			$conditions,
 			__METHOD__,
 			$options,
-			[ $db->tableName( SQLStore::ID_TABLE ) => [ 'INNER JOIN', [ 'smw_id=p_id' ] ] ]
+			[ SQLStore::ID_TABLE => [ 'INNER JOIN', [ 'smw_id=p_id' ] ] ]
 		);
 
 		return $res->numRows();
@@ -306,13 +306,13 @@ class UsageStatisticsListLookup implements ListLookup {
 
 		// Select object ID's against known property ID's that match the conditions
 		$res = $db->select(
-			[ $db->tableName( SQLStore::ID_TABLE ), $db->tableName( SQLStore::PROPERTY_STATISTICS_TABLE ) ],
+			[ SQLStore::ID_TABLE, SQLStore::PROPERTY_STATISTICS_TABLE ],
 			'smw_id',
 			$conditions,
 			__METHOD__,
 			$options,
 			[
-				$db->tableName( SQLStore::ID_TABLE ) => [ 'INNER JOIN', [ 'smw_id=p_id' ] ]
+				SQLStore::ID_TABLE => [ 'INNER JOIN', [ 'smw_id=p_id' ] ]
 			]
 		);
 

--- a/src/SQLStore/PropertyStatisticsStore.php
+++ b/src/SQLStore/PropertyStatisticsStore.php
@@ -282,7 +282,7 @@ class PropertyStatisticsStore {
 		}
 
 		$propertyStatistics = $this->connection->select(
-			$this->connection->tablename( SQLStore::PROPERTY_STATISTICS_TABLE ),
+			SQLStore::PROPERTY_STATISTICS_TABLE,
 			[
 				'usage_count',
 				'p_id',

--- a/src/SQLStore/PropertyTableRowDiffer.php
+++ b/src/SQLStore/PropertyTableRowDiffer.php
@@ -291,7 +291,7 @@ class PropertyTableRowDiffer {
 		$connection = $this->store->getConnection( 'mw.db' );
 
 		$result = $connection->select(
-			$connection->tablename( $propertyTable->getName() ),
+			$propertyTable->getName(),
 			'*',
 			[ 's_id' => $sid ],
 			__METHOD__

--- a/tests/phpunit/SQLStore/Lookup/ByGroupPropertyValuesLookupTest.php
+++ b/tests/phpunit/SQLStore/Lookup/ByGroupPropertyValuesLookupTest.php
@@ -43,10 +43,6 @@ class ByGroupPropertyValuesLookupTest extends \PHPUnit\Framework\TestCase {
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'tablename' )
-			->willReturnArgument( 0 );
-
-		$connection->expects( $this->any() )
 			->method( 'addQuotes' )
 			->willReturnArgument( 0 );
 
@@ -125,10 +121,6 @@ class ByGroupPropertyValuesLookupTest extends \PHPUnit\Framework\TestCase {
 		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Connection\Database' )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$connection->expects( $this->any() )
-			->method( 'tablename' )
-			->willReturnArgument( 0 );
 
 		$connection->expects( $this->any() )
 			->method( 'addQuotes' )
@@ -213,10 +205,6 @@ class ByGroupPropertyValuesLookupTest extends \PHPUnit\Framework\TestCase {
 		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Connection\Database' )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$connection->expects( $this->any() )
-			->method( 'tablename' )
-			->willReturnArgument( 0 );
 
 		$connection->expects( $this->any() )
 			->method( 'addQuotes' )

--- a/tests/phpunit/SQLStore/Lookup/DisplayTitleLookupTest.php
+++ b/tests/phpunit/SQLStore/Lookup/DisplayTitleLookupTest.php
@@ -58,10 +58,6 @@ class DisplayTitleLookupTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->once() )
-			->method( 'tablename' )
-			->willReturnArgument( 0 );
-
 		$connection->expects( $this->any() )
 			->method( 'unescape_bytea' )
 			->willReturnArgument( 0 );


### PR DESCRIPTION
as MW DBAL resolves names already

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **重构**
  * 简化了数据库查询中表名的引用方式，直接使用表名常量，移除了对 tableName() 方法的调用，提高了代码可读性和一致性。
* **测试**
  * 更新了相关单元测试，移除了对 tableName 方法调用的模拟和断言，保持测试逻辑不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->